### PR TITLE
fix(adapters): add backward compatibility code to create a readStream…

### DIFF
--- a/e2e-tests/index.test.ts
+++ b/e2e-tests/index.test.ts
@@ -1,7 +1,7 @@
 import t from "tap";
 import path from "node:path";
 import { readFile } from "node:fs/promises";
-import { execCmd } from './test-utils/exec-cmd';
+import { execCmd } from "./test-utils/exec-cmd";
 
 t.test(
 	"published version in the distribution channel match the current branch",
@@ -16,5 +16,35 @@ t.test(
 
 		t.ok(stderr.length === 0, `stderr: ${stderr}`);
 		t.match(stdout, new RegExp(`${pkg.version}`, "gi"));
+	},
+);
+
+t.test(
+	"enchecker display a list with missing variables when aren't found",
+	async (t) => {
+		const { stdout, stderr } = await execCmd(
+			"envchecker --src=./test-cases/single-plain-file/constants.js --check-env=./test-cases/single-plain-file/.env.failure",
+			{
+				cwd: __dirname
+			}
+		);
+
+		t.ok(stderr.length === 0, `stderr: ${stderr}`);
+		t.match(stdout, /missing variables:\n\s-\sBASE_URL\n/g);
+	},
+);
+
+t.test(
+	"enchecker display green check when all variables are documented",
+	async (t) => {
+		const { stdout, stderr } = await execCmd(
+			"envchecker --src=./test-cases/single-plain-file/constants.js --check-env=./test-cases/single-plain-file/.env.success",
+			{
+				cwd: __dirname
+			}
+		);
+
+		t.ok(stderr.length === 0, `stderr: ${stderr}`);
+		t.match(stdout, /\u2713 Environment variables documented\n/gu);
 	},
 );

--- a/e2e-tests/test-cases/single-plain-file/.env.failure
+++ b/e2e-tests/test-cases/single-plain-file/.env.failure
@@ -1,0 +1,1 @@
+DB_HOST=localhost

--- a/e2e-tests/test-cases/single-plain-file/.env.success
+++ b/e2e-tests/test-cases/single-plain-file/.env.success
@@ -1,0 +1,2 @@
+DB_HOST=localhost
+BASE_URL=http://api.example.com/v1/

--- a/e2e-tests/test-cases/single-plain-file/constants.js
+++ b/e2e-tests/test-cases/single-plain-file/constants.js
@@ -1,0 +1,2 @@
+const baseUrl = process.env.BASE_URL;
+const dbHost = process.env.DB_HOST;

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "scripts": {
     "build": "npm run clean && tsc --pretty --skipLibCheck --noEmit && webpack",
-    "test": "npx tap --ts --test-ignore=e2e-tests\/.*",
-    "e2e-tests": "npx tap --ts ./e2e-tests",
+    "test": "npx tap --ts --test-ignore=e2e-tests\/.* --no-check-coverage",
+    "e2e-tests": "npx tap --ts ./e2e-tests --no-check-coverage",
     "clean": "npx shx rm -rf bin",
     "format": "rome format .",
     "commit": "cz",


### PR DESCRIPTION
… from a filehandler

createReadStream method was added to the FileHandler class since v16.11.0. In previous versions createReadStream has to be imported from fs module